### PR TITLE
fix: pin dependency versions, remove ^ ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "axios": "0.21.1",
     "commander": "7.2.0",
     "fast-stats": "0.0.7",
-    "lodash": "^4.17.21",
+    "lodash": "4.17.21",
     "moment": "2.29.1",
     "nginxparser": "2.1.0",
-    "plotly.js-dist-min": "^3.1.0",
-    "readline": "^1.3.0",
+    "plotly.js-dist-min": "3.1.0",
+    "readline": "1.3.0",
     "winston": "3.3.3"
   }
 }


### PR DESCRIPTION
## Summary
Remove `^` prefix from all dependency versions in package.json to pin exact versions and prevent unexpected updates.

### Changes (3 dependencies):
```
  lodash: ^4.17.21 → 4.17.21
  plotly.js-dist-min: ^3.1.0 → 3.1.0
  readline: ^1.3.0 → 1.3.0
```


## Why
Caret (`^`) ranges allow npm to install newer minor/patch versions automatically. This can introduce breaking changes or security vulnerabilities without explicit review.

## Test plan
- [ ] Run `npm install` and verify no errors
- [ ] Run existing tests to confirm nothing is broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)